### PR TITLE
add a setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+MANIFEST
+build
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include doc/SYNTAX

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+
+setup(name='cronex',
+      version='0.1.0',
+      description='This module provides an easy to use interface for cron-like task scheduling.',
+      author='James (Eric) Pruitt',
+      author_email='eric.pruitt@gmail.com',
+      url='https://github.com/ericpruitt/cronex',
+      py_modules=['cronex'],
+     )


### PR DESCRIPTION
There's currently no easy way to install this package, although I would find it to be useful.  This should make it possible to install cronex with pip
