### PR TITLE
add equivalence methods to CronExpression

### DIFF
--- a/cronex/__init__.py
+++ b/cronex/__init__.py
@@ -126,6 +126,17 @@ class CronExpression(object):
     def __str__(self):
         return repr(self)
 
+    def __eq__(self, other):
+        if not hasattr(other, 'string_tab'):
+            return False
+        return self.string_tab == other.string_tab
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is not NotImplemented:
+            return not result
+        return NotImplemented
+
     def compute_numtab(self):
         """
         Recomputes the sets for the static ranges of the trigger time.

--- a/cronex/tests.py
+++ b/cronex/tests.py
@@ -425,6 +425,13 @@ class test_testedmodule(unittest.TestCase):
             return
         cronex.CronExpression(unicode("* * * * * ABC"))
 
+    def test_equivalence(self):
+        line = "* * * * *"
+        alt_line = "* * * * 1"
+        self.assertEqual(cronex.CronExpression(line), cronex.CronExpression(line))
+        self.assertNotEqual(cronex.CronExpression(line), cronex.CronExpression(alt_line))
+        self.assertNotEqual(cronex.CronExpression(line), 'some other object')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hey @ericpruitt,

I've run into trouble with testing a project which uses your library.

I found `CronExpression(every_minute) != CronExpression(every_minute)`.

This patch resolves this.